### PR TITLE
create local team if needed when adding a committer

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -365,7 +365,8 @@ public class IrcBotImpl extends PircBot {
             GitHub github = GitHub.connect();
             GHUser c = github.getUser(collaborator);
             GHOrganization o = github.getOrganization("jenkinsci");
-            GHTeam t = justForThisRepo==null ? o.getTeams().get("Everyone") : o.getTeams().get(justForThisRepo+" Developers");
+            GHTeam t = justForThisRepo==null ? o.getTeams().get("Everyone") 
+                                             : getOrCreateRepoLocalTeam(o, o.getRepository(justForThisRepo));
             if (t==null) {
                 sendMessage(channel,"No team for "+justForThisRepo);
                 return;


### PR DESCRIPTION
as a workaround for failure creating the team after forking a github repo
