### PR TITLE
Quick IRC bot fixes and improvements

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -91,7 +91,7 @@ public class IrcBotImpl extends PircBot {
         String prefix = getNick() + ":";
         if (!message.startsWith(prefix)) {
             // not send to me
-            Matcher m = Pattern.compile("(?:hudson-|jenkins-|bug )([0-9]+)",CASE_INSENSITIVE).matcher(message);
+            Matcher m = Pattern.compile("(?:hudson-|jenkins-|bug )([0-9]{2,})",CASE_INSENSITIVE).matcher(message);
             while (m.find()) {
                 replyBugStatus(channel,m.group(1));
             }
@@ -318,7 +318,7 @@ public class IrcBotImpl extends PircBot {
 
         sendMessage("CHANSERV", "flags " + channel + " " + target + " +V");
         sendMessage("CHANSERV", "voice " + channel + " " + target);
-        sendMessage(channel, "Voice priviledge (+V) added for " + target);
+        sendMessage(channel, "Voice privilege (+V) added for " + target);
     }
 
     private void removeAutoVoice(String channel, String sender, String target) {
@@ -329,7 +329,7 @@ public class IrcBotImpl extends PircBot {
 
       sendMessage("CHANSERV", "flags " + channel + " " + target + " -V");
       sendMessage("CHANSERV", "devoice " + channel + " " + target);
-      sendMessage(channel, "Voice priviledge (-V) removed for " + target);
+      sendMessage(channel, "Voice privilege (-V) removed for " + target);
     }
 
     private void createGitHubRepository(String channel, String name, String collaborator) {


### PR DESCRIPTION
I pasted in a GitHub repo URL from the mailing list earlier, and it took me a moment to realise why `jenkins-admin` failed — it expects only the username and repo name.

Now we can just paste in the full GitHub URL.

Also, I prevented the oft-occurring false positive where the bot pulls the info for issue `JENKINS-1`.
