### PR TITLE
Fix bot's 'Failed to create a repository: {"message":"Server Error"}' error message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.29</version>
+      <version>1.37</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -374,7 +374,9 @@ public class IrcBotImpl extends PircBot {
             }
 
             t.add(c);
-            o.publicize(c);
+            if (!o.hasPublicMember(c)) {
+                o.publicize(c);
+            }
             sendMessage(channel,"Added "+collaborator+" as a GitHub committer");
         } catch (IOException e) {
             sendMessage(channel,"Failed to create a repository: "+e.getMessage());


### PR DESCRIPTION
When GHOrganization#publicize method argument is a GHUser that is already publicizing its membership, GitHub returns error 500, causing the API to fail.

This commit fixes this behaviour with a prior verification whether the organization has the user or not.

This verification is made with GHOrganization#hasPublicMembers(GHUser). As this method is not available in github-api-1.28, the pom.xml was updated to version 1.37, which contains the missing method.

I used TupiLabs organization and some of its repositories/members to test this error, and this change seems to fix it. 

Thanks
