### PR TITLE
Dont add committers to everyone group by default

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -652,22 +652,6 @@ public class IrcBotImpl extends PircBot {
             // GitHub adds a lot of teams to this repo by default, which we don't want
             Set<GHTeam> legacyTeams = r.getTeams();
 
-            GHTeam defaultTeam = org.getTeams().get(IrcBotConfig.GITHUB_DEFAULT_TEAM);
-            if (defaultTeam == null) {
-                sendMessage(channel, "Cannot find the default team \""+ IrcBotConfig.GITHUB_DEFAULT_TEAM + 
-                        "\" for" + IrcBotConfig.GITHUB_ORGANIZATION+" organization. The team won't be added to the repo");
-            } else {
-                try {
-                    defaultTeam.add(user);
-                } catch (IOException e) {  // if 'user' is an org, the above command would fail
-                    sendMessage(channel,"Failed to add "+user+" to \""+IrcBotConfig.GITHUB_DEFAULT_TEAM+"\" team. Maybe an org?: "+e.getMessage());
-                    // fall through
-                }
-                
-                // the default group gets access to this new repository, too.
-                defaultTeam.add(r);
-            }
-
             GHTeam t = getOrCreateRepoLocalTeam(org, r);
             try {
                 t.add(user);    // the user immediately joins this team


### PR DESCRIPTION
When forking a repo of the form

   https://github.com/pouet/therepo-plugin

with the classic:

    fork https://github.com/pouet/therepo-plugin as therepo-plugin

pouet user will automatically be added to the 'Everyone' group.

This is counter-intuitive, IMO, and non consistent with the same usage
when pouet is an org.

You'll end up doing N calls to:

    make someone committer of therepo-plugin

to give her/him access.

Hence this modification makes the behaviour more consistent across those
two cases, and more explicit.