### PR TITLE
Fix issue with forking and few typo fixes

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -403,8 +403,8 @@ public class IrcBotImpl extends PircBot {
                     + "* [Accept the invitation to the Jenkins CI Org on Github|https://github.com/jenkinsci]\n"
                     + "* [Request upload permission|https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins#HostingPlugins-Requestuploadpermissions]\n"
                     + "* [Releasing your plugin|https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins#HostingPlugins-Releasingtojenkins-ci.org]\n"
-                    + "\n\nIn order for your plugin to be built by the Jenkins CI infrastructure and check PR's, please add a [Jenkinsfile|https://jenkins.io/doc/book/pipeline/jenkinsfile/] to the root "
-                    + "of your repository with the following content:\n"
+                    + "\n\nIn order for your plugin to be built by the [Jenkins CI Infrastructure|https://ci.jenkins.io] and check pull requests,"
+                    + " please add a [Jenkinsfile|https://jenkins.io/doc/book/pipeline/jenkinsfile/] to the root of your repository with the following content:\n"
                     + "{code}\nbuildPlugin()\n{code}"
                     + "\n\nWelcome aboard!";
 

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -321,7 +321,7 @@ public class IrcBotImpl extends PircBot {
         }
 
         kick(channel, target);
-        sendMessage(channel, "Kicked user" + target);
+        sendMessage(channel, "Kicked user " + target);
     }
 
     private void setupHosting(String channel, String sender, String hostingId, String defaultForkTo) {
@@ -403,6 +403,9 @@ public class IrcBotImpl extends PircBot {
                     + "* [Accept the invitation to the Jenkins CI Org on Github|https://github.com/jenkinsci]\n"
                     + "* [Request upload permission|https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins#HostingPlugins-Requestuploadpermissions]\n"
                     + "* [Releasing your plugin|https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins#HostingPlugins-Releasingtojenkins-ci.org]\n"
+                    + "\n\nIn order for your plugin to be built by the Jenkins CI infrastructure and check PR's, please add a [Jenkinsfile|https://jenkins.io/doc/book/pipeline/jenkinsfile/] to the root "
+                    + "of your repository with the following content:\n"
+                    + "{code}\nbuildPlugin()\n{code}"
                     + "\n\nWelcome aboard!";
 
             // add comment
@@ -774,7 +777,7 @@ public class IrcBotImpl extends PircBot {
             sendMessage(channel,successMsg);
             result = true;
         } catch (IOException e) {
-            sendMessage(channel,"Failed to create a repository: "+e.getMessage());
+            sendMessage(channel,"Failed to add user to team: "+e.getMessage());
             e.printStackTrace();
         }
         return result;
@@ -822,6 +825,12 @@ public class IrcBotImpl extends PircBot {
             GHRepository check = org.getRepository(newName);
             if(check != null) {
                 sendMessage(channel,"Repository with name "+newName+" already exists in "+IrcBotConfig.GITHUB_ORGANIZATION);
+                return false;
+            }
+
+            check = org.getRepository(repo);
+            if(check != null) {
+                sendMessage(channel, "Repository "+repo+" can't be forked, an existing repository with that name already exists in "+IrcBotConfig.GITHUB_ORGANIZATION);
                 return false;
             }
 

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotImplTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotImplTest.java
@@ -6,9 +6,12 @@ import org.jibble.pircbot.User;
 import org.junit.runner.RunWith;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTeam;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -43,6 +46,74 @@ public class IrcBotImplTest extends TestCase {
         Mockito.when(gho.getRepository(repoName)).thenReturn(repo);
 
         Mockito.when(gh.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION)).thenReturn(gho);
+
+        System.setProperty("ircbot.testSuperUser", botUser);
+
+        IrcBotImpl bot = new IrcBotImpl(null);
+        Method m = PircBot.class.getDeclaredMethod("addUser", String.class, User.class);
+        if(m != null) {
+            m.setAccessible(true);
+            Constructor<User> bc = User.class.getDeclaredConstructor(String.class, String.class);
+            if(bc != null) {
+                bc.setAccessible(true);
+                User bot_user = bc.newInstance("+", botUser);
+                m.invoke(bot, channel, bot_user);
+                User[] users = bot.getUsers(channel);
+                assertEquals(users.length, 1);
+                assertEquals(users[0].getPrefix(), "+");
+                assertEquals(users[0].getNick(), botUser);
+                assertFalse(bot.forkGitHub(channel, botUser, owner, from, repoName));
+            } else {
+                fail("Could not get User constructor");
+            }
+        } else {
+            fail("Could not get addUser method");
+        }
+    }
+    public void testForkOriginSameNameAsExisting() throws Exception {
+        final String repoName = "some-new-name";
+        final String channel = "#dummy";
+        final String botUser = "bot-user";
+        final String owner = "bar";
+        final String from = "jenkins";
+
+        PowerMockito.mockStatic(GitHub.class);
+
+        GitHub gh = Mockito.mock(GitHub.class);
+        Mockito.when(GitHub.connect()).thenReturn(gh);
+
+        GHRepository originRepo = Mockito.mock(GHRepository.class);
+        final GHRepository newRepo = Mockito.mock(GHRepository.class);
+
+        GHUser user = Mockito.mock(GHUser.class);
+        Mockito.when(gh.getUser(owner)).thenReturn(user);
+        Mockito.when(user.getRepository(from)).thenReturn(originRepo);
+
+        GHRepository repo = Mockito.mock(GHRepository.class);
+        final GHOrganization gho = Mockito.mock(GHOrganization.class);
+        Mockito.when(gho.getRepository(from)).thenReturn(repo);
+
+        Mockito.when(gh.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION)).thenReturn(gho);
+
+        Mockito.when(originRepo.forkTo(gho)).thenReturn(newRepo);
+        Mockito.when(newRepo.getName()).thenReturn(repoName);
+
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                if (arguments != null && arguments.length > 0 && arguments[0] != null) {
+                    String newName = (String) arguments[0];
+                    Mockito.when(gho.getRepository(newName)).thenReturn(newRepo);
+                }
+                return null;
+            }
+        }).when(newRepo).renameTo(repoName);
+
+        GHTeam t = Mockito.mock(GHTeam.class);
+        Mockito.doNothing().when(t).add(user);
+
+        Mockito.when(gho.createTeam("some-new-name Developers", GHOrganization.Permission.ADMIN, newRepo)).thenReturn(t);
 
         System.setProperty("ircbot.testSuperUser", botUser);
 


### PR DESCRIPTION
- Do not allow forking a repository that is named as an existing repository in the org.
- Fix typo in kick message
- Fix incorrect message when trying to add a user to a team