### PR TITLE
Allow forking if the repo exists as a rename redirection.

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -828,9 +828,12 @@ public class IrcBotImpl extends PircBot {
                 return false;
             }
 
+            // check if there is an existing real (not-renamed) repository with the name
+            // if a repo has been forked and renamed, we can clone as that name and be fine
+            // we just want to make sure we don't fork to an current repository name.
             check = org.getRepository(repo);
-            if(check != null) {
-                sendMessage(channel, "Repository "+repo+" can't be forked, an existing repository with that name already exists in "+IrcBotConfig.GITHUB_ORGANIZATION);
+            if(check != null && check.getName().equalsIgnoreCase(repo.toLowerCase())) {
+                sendMessage(channel, "Repository " + repo + " can't be forked, an existing repository with that name already exists in " + IrcBotConfig.GITHUB_ORGANIZATION);
                 return false;
             }
 

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -832,7 +832,7 @@ public class IrcBotImpl extends PircBot {
             // if a repo has been forked and renamed, we can clone as that name and be fine
             // we just want to make sure we don't fork to an current repository name.
             check = org.getRepository(repo);
-            if(check != null && check.getName().equalsIgnoreCase(repo.toLowerCase())) {
+            if(check != null && check.getName().equalsIgnoreCase(repo)) {
                 sendMessage(channel, "Repository " + repo + " can't be forked, an existing repository with that name already exists in " + IrcBotConfig.GITHUB_ORGANIZATION);
                 return false;
             }

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotImplTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotImplTest.java
@@ -88,10 +88,12 @@ public class IrcBotImplTest extends TestCase {
         GHUser user = Mockito.mock(GHUser.class);
         Mockito.when(gh.getUser(owner)).thenReturn(user);
         Mockito.when(user.getRepository(from)).thenReturn(originRepo);
+        Mockito.when(originRepo.getName()).thenReturn(from);
 
         GHRepository repo = Mockito.mock(GHRepository.class);
         final GHOrganization gho = Mockito.mock(GHOrganization.class);
         Mockito.when(gho.getRepository(from)).thenReturn(repo);
+        Mockito.when(repo.getName()).thenReturn(from);
 
         Mockito.when(gh.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION)).thenReturn(gho);
 
@@ -138,4 +140,76 @@ public class IrcBotImplTest extends TestCase {
             fail("Could not get addUser method");
         }
     }
+
+    public void testForkOriginSameNameAsRenamed() throws Exception {
+        final String repoName = "some-new-name";
+        final String channel = "#dummy";
+        final String botUser = "bot-user";
+        final String owner = "bar";
+        final String from = "jenkins";
+
+        PowerMockito.mockStatic(GitHub.class);
+
+        GitHub gh = Mockito.mock(GitHub.class);
+        Mockito.when(GitHub.connect()).thenReturn(gh);
+
+        GHRepository originRepo = Mockito.mock(GHRepository.class);
+        final GHRepository newRepo = Mockito.mock(GHRepository.class);
+
+        GHUser user = Mockito.mock(GHUser.class);
+        Mockito.when(gh.getUser(owner)).thenReturn(user);
+        Mockito.when(user.getRepository(from)).thenReturn(originRepo);
+        Mockito.when(originRepo.getName()).thenReturn(from);
+
+        GHRepository repo = Mockito.mock(GHRepository.class);
+        final GHOrganization gho = Mockito.mock(GHOrganization.class);
+        Mockito.when(gho.getRepository(from)).thenReturn(repo);
+        Mockito.when(repo.getName()).thenReturn("othername");
+
+        Mockito.when(gh.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION)).thenReturn(gho);
+
+        Mockito.when(originRepo.forkTo(gho)).thenReturn(newRepo);
+        Mockito.when(newRepo.getName()).thenReturn(repoName);
+
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                if (arguments != null && arguments.length > 0 && arguments[0] != null) {
+                    String newName = (String) arguments[0];
+                    Mockito.when(gho.getRepository(newName)).thenReturn(newRepo);
+                }
+                return null;
+            }
+        }).when(newRepo).renameTo(repoName);
+
+        GHTeam t = Mockito.mock(GHTeam.class);
+        Mockito.doNothing().when(t).add(user);
+
+        Mockito.when(gho.createTeam("some-new-name Developers", GHOrganization.Permission.ADMIN, newRepo)).thenReturn(t);
+
+        System.setProperty("ircbot.testSuperUser", botUser);
+
+        IrcBotImpl bot = new IrcBotImpl(null);
+        Method m = PircBot.class.getDeclaredMethod("addUser", String.class, User.class);
+        if(m != null) {
+            m.setAccessible(true);
+            Constructor<User> bc = User.class.getDeclaredConstructor(String.class, String.class);
+            if(bc != null) {
+                bc.setAccessible(true);
+                User bot_user = bc.newInstance("+", botUser);
+                m.invoke(bot, channel, bot_user);
+                User[] users = bot.getUsers(channel);
+                assertEquals(users.length, 1);
+                assertEquals(users[0].getPrefix(), "+");
+                assertEquals(users[0].getNick(), botUser);
+                assertTrue(bot.forkGitHub(channel, botUser, owner, from, repoName));
+            } else {
+                fail("Could not get User constructor");
+            }
+        } else {
+            fail("Could not get addUser method");
+        }
+    }
+
 }


### PR DESCRIPTION
Github will redirect the old name of a repo to the new name, this checks if the
repo is actually named the same and is existing.

cc: @daniel-beck 