### PR TITLE
[INFRA-1740] First register 'jenkins-admin' user before joining channel

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotImpl.java
@@ -944,12 +944,14 @@ public class IrcBotImpl extends PircBot {
         System.out.println("GitHub organization = "+IrcBotConfig.GITHUB_ORGANIZATION);
         bot.connect(IrcBotConfig.SERVER);
         bot.setVerbose(true);
-        for (String channel : IrcBotConfig.getChannels()) {
-            bot.joinChannel(channel);
-        }
         if (args.length>0) {
             System.out.println("Authenticating with NickServ");
             bot.sendMessage("nickserv","identify "+args[0]);
+            TimeUnit.SECONDS.sleep(5);
+        }
+
+        for (String channel : IrcBotConfig.getChannels()) {
+            bot.joinChannel(channel);
         }
     }
 


### PR DESCRIPTION
Currently the ircbot try to first join channels before registering the jenkins-admin user. 
Because jenkins channel are now set to +r since since [INFRA-1732](https://issues.jenkins-ci.org/browse/INFRA-1493) , the ircbot is running but has not joined any channels.