### PR TITLE
Run ircbot from tini -- /bin/sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,15 @@ RUN adduser -D -h /home/ircbot -u 1013 ircbot
 ADD target/ircbot-2.0-SNAPSHOT-bin.zip /usr/local/bin/ircbot.zip
 RUN cd /usr/local/bin; unzip ircbot.zip
 
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+RUN chmod +x /tini
+
 EXPOSE 8080
 USER ircbot
 
-ENTRYPOINT ["java", "-Dircbot.name=jenkins-admin", "-jar", "/usr/local/bin/ircbot-2.0-SNAPSHOT.jar"]
+ENTRYPOINT [\
+  "/tini", "--",\
+  "/bin/sh","-c",\
+  "java -Dircbot.name=jenkins-admin -jar /usr/local/bin/ircbot-2.0-SNAPSHOT.jar"]


### PR DESCRIPTION
We have to configure the nickname's password from a environment variable and it required the two following elements:
* /bin/sh -> to load environment variable
* /tini to handle the java process and kill the container in case of issue as the process doesn't have the pid 1