### PR TITLE
Make new teams visible to org members

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
           <url>http://www.opensource.org/licenses/mit-license.php</url>
           <distribution>repo</distribution>
       </license>
-  </licenses>	
+  </licenses>
 
   <build>
     <plugins>
@@ -66,7 +66,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -86,7 +86,8 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.89</version>
+      <classifier>shaded</classifier>
+      <version>1.104-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <classifier>shaded</classifier>
-      <version>1.104-SNAPSHOT</version>
+      <version>1.105</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -833,7 +833,7 @@ public class IrcListener extends ListenerAdapter {
                      out.message("Could not find repository:  "+justForThisRepo);
                      return false;
                  }
-                 t = getOrCreateRepoLocalTeam(o, forThisRepo, null);
+                 t = getOrCreateRepoLocalTeam(o, forThisRepo, emptyList());
 
             if (t==null) {
                 out.message("No team for "+justForThisRepo);

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -16,8 +16,8 @@ import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.util.concurrent.Promise;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.backend.ircbot.fallback.FallbackMessage;
-import org.kohsuke.github.GHCreateTeamBuilder;
 import org.kohsuke.github.GHOrganization.Permission;
+import org.kohsuke.github.GHTeamBuilder;
 import org.pircbotx.*;
 import org.pircbotx.cap.SASLCapHandler;
 import org.pircbotx.hooks.ListenerAdapter;
@@ -54,7 +54,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.*;
 import javax.annotation.CheckForNull;
 
@@ -1001,9 +1000,9 @@ public class IrcListener extends ListenerAdapter {
         String teamName = r.getName() + " Developers";
         GHTeam t = org.getTeams().get(teamName);
         if (t==null) {
-            GHCreateTeamBuilder ghCreateTeamBuilder = org.createTeam(teamName).privacy(GHTeam.Privacy.CLOSED);
+            GHTeamBuilder ghCreateTeamBuilder = org.createTeam(teamName).privacy(GHTeam.Privacy.CLOSED);
             if (githubUserName != null) {
-                ghCreateTeamBuilder = ghCreateTeamBuilder.maintainers(singletonList(githubUserName));
+                ghCreateTeamBuilder = ghCreateTeamBuilder.maintainers(githubUserName);
             }
             t = ghCreateTeamBuilder.create();
             t.add(r, Permission.ADMIN); // make team an admin on the given repository

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -838,7 +838,7 @@ public class IrcListener extends ListenerAdapter {
                 return false;
             }
 
-            t = getOrCreateRepoLocalTeam(o, forThisRepo);
+            t = getOrCreateRepoLocalTeam(o, forThisRepo, emptyList());
             t.add(c);
             out.message("Added " + collaborator + " as a GitHub committer for repository " + justForThisRepo);
             result = true;

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -759,8 +759,7 @@ public class IrcListener extends ListenerAdapter {
 
             ghTeam.setPrivacy(GHTeam.Privacy.CLOSED);
 
-            String successMsg = "Made GitHub team " + team + " visible";
-            out.message(successMsg);
+            out.message("Made GitHub team " + team + " visible");
             result = true;
         } catch (IOException e) {
             out.message("Failed to make GitHub team " + team + " visible: " + e.getMessage());
@@ -794,8 +793,7 @@ public class IrcListener extends ListenerAdapter {
             }
 
             ghTeam.add(c, GHTeam.Role.MAINTAINER);
-            String successMsg = "Added " + newTeamMaintainer + " as a GitHub maintainer for team " + team;
-            out.message(successMsg);
+            out.message("Added " + newTeamMaintainer + " as a GitHub maintainer for team " + team);
             result = true;
         } catch (IOException e) {
             out.message("Failed to make user maintainer of team: " + e.getMessage());
@@ -841,8 +839,7 @@ public class IrcListener extends ListenerAdapter {
             }
 
             t.add(c);
-            String successMsg = "Added "+collaborator+" as a GitHub committer for repository " + justForThisRepo;
-            out.message(successMsg);
+            out.message("Added " + collaborator + " as a GitHub committer for repository " + justForThisRepo);
             result = true;
         } catch (IOException e) {
             out.message("Failed to add user to team: "+e.getMessage());

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTeam;
+import org.kohsuke.github.GHTeamBuilder;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.mockito.Mockito;
@@ -176,10 +177,16 @@ public class IrcListenerTest extends TestCase {
             }
         }).when(newRepo).renameTo(repoName);
 
+        GHTeamBuilder teamBuilder = mock(GHTeamBuilder.class);
+
+        when(gho.createTeam("some-new-name Developers")).thenReturn(teamBuilder);
+        when(teamBuilder.privacy(GHTeam.Privacy.CLOSED)).thenReturn(teamBuilder);
+
         GHTeam t = mock(GHTeam.class);
+        when(teamBuilder.create()).thenReturn(t);
+
         Mockito.doNothing().when(t).add(user);
 
-        when(gho.createTeam("some-new-name Developers", GHOrganization.Permission.PULL, newRepo)).thenReturn(t);
         Mockito.doNothing().when(t).add(newRepo, GHOrganization.Permission.ADMIN);
 
         System.setProperty("ircbot.testSuperUser", botUser);

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -21,6 +21,8 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static java.util.Collections.emptyList;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -67,7 +69,7 @@ public class IrcListenerTest extends TestCase {
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
 
-        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName));
+        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
     }
 
     public void testForkOriginSameNameAsExisting() throws Exception {
@@ -115,8 +117,6 @@ public class IrcListenerTest extends TestCase {
         GHTeam t = mock(GHTeam.class);
         Mockito.doNothing().when(t).add(user);
 
-        when(gho.createTeam("some-new-name Developers", GHOrganization.Permission.ADMIN, newRepo)).thenReturn(t);
-
         System.setProperty("ircbot.testSuperUser", botUser);
 
         IrcListener ircListener = new IrcListener(null);
@@ -132,7 +132,7 @@ public class IrcListenerTest extends TestCase {
         ImmutableSortedSet.Builder<UserLevel> builder = ImmutableSortedSet.naturalOrder();
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
-        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName));
+        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
     }
 
     public void testForkOriginSameNameAsRenamed() throws Exception {
@@ -180,13 +180,11 @@ public class IrcListenerTest extends TestCase {
         GHTeamBuilder teamBuilder = mock(GHTeamBuilder.class);
 
         when(gho.createTeam("some-new-name Developers")).thenReturn(teamBuilder);
+        when(teamBuilder.maintainers(any())).thenReturn(teamBuilder);
         when(teamBuilder.privacy(GHTeam.Privacy.CLOSED)).thenReturn(teamBuilder);
 
         GHTeam t = mock(GHTeam.class);
         when(teamBuilder.create()).thenReturn(t);
-
-        Mockito.doNothing().when(t).add(user);
-
         Mockito.doNothing().when(t).add(newRepo, GHOrganization.Permission.ADMIN);
 
         System.setProperty("ircbot.testSuperUser", botUser);
@@ -204,6 +202,6 @@ public class IrcListenerTest extends TestCase {
         ImmutableSortedSet.Builder<UserLevel> builder = ImmutableSortedSet.naturalOrder();
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
-        assertTrue(ircListener.forkGitHub(chan, sender, owner, from, repoName));
+        assertTrue(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
     }
 }


### PR DESCRIPTION
Requires https://github.com/github-api/github-api/pull/683

Ref: https://groups.google.com/d/msg/jenkinsci-dev/U_lFkTzmg1E/S-5Q7IVdBQAJ

This PR does:
1. New teams created will be 'visible' (org members can see them and they show up in the reviewers list if CODEOWNERS are used)
2. All users in the HOSTING request will be made a 'Maintainer' of the GH team
3. Adds a new command for making a secret team visible
4. Adds a command to add a user as a maintainer of a team

Docs: https://github.com/jenkins-infra/jenkins.io/pull/2802