### PR TITLE
Don't disable GitHub issues by default

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -911,7 +911,6 @@ public class IrcListener extends ListenerAdapter {
      * Fix up the repository set up to our policy.
      */
     private void setupRepository(GHRepository r) throws IOException {
-        r.enableIssueTracker(false);
         r.enableWiki(false);
     }
 


### PR DESCRIPTION
Lots of plugins are using GitHub issues now, would be good to not disable by default