### PR TITLE
Fix issue with voice/devoice commands

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -701,8 +701,8 @@ public class IrcListener extends ListenerAdapter {
         }
 
         OutputIRC out = channel.getBot().sendIRC();
-        out.message("CHANSERV", "flags " + channel + " " + target + " +V");
-        out.message("CHANSERV", "voice " + channel + " " + target);
+        out.message("CHANSERV", "flags " + channel.getName() + " " + target + " +V");
+        out.message("CHANSERV", "voice " + channel.getName() + " " + target);
         channel.send().message("Voice privilege (+V) added for " + target);
     }
 
@@ -713,8 +713,8 @@ public class IrcListener extends ListenerAdapter {
         }
 
         OutputIRC out = channel.getBot().sendIRC();
-        out.message("CHANSERV", "flags " + channel + " " + target + " -V");
-        out.message("CHANSERV", "devoice " + channel + " " + target);
+        out.message("CHANSERV", "flags " + channel.getName() + " " + target + " -V");
+        out.message("CHANSERV", "devoice " + channel.getName() + " " + target);
         channel.send().message("Voice privilege (-V) removed for " + target);
     }
 


### PR DESCRIPTION
There is no `Channel.toString()` method implemented, so without `.getName()` on the channel object, it won't be the correct string for the actual channel, it will be some description of the class.