### PR TITLE
Revert "[INFRA-2545] Possible fix"

### DIFF
--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -21,8 +21,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Collections;
-
 import static java.util.Collections.emptyList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -155,9 +153,6 @@ public class IrcListenerTest extends TestCase {
         GHUser user = mock(GHUser.class);
         when(gh.getUser(owner)).thenReturn(user);
         when(user.getRepository(from)).thenReturn(originRepo);
-        when(user.getName()).thenReturn(owner);
-        when(user.getType()).thenReturn("User");
-        when(user.getLogin()).thenReturn(owner);
         when(originRepo.getName()).thenReturn(from);
 
         GHRepository repo = mock(GHRepository.class);
@@ -191,7 +186,6 @@ public class IrcListenerTest extends TestCase {
         GHTeam t = mock(GHTeam.class);
         when(teamBuilder.create()).thenReturn(t);
         Mockito.doNothing().when(t).add(newRepo, GHOrganization.Permission.ADMIN);
-        when(t.getMembers()).thenReturn(Collections.singleton(user));
 
         System.setProperty("ircbot.testSuperUser", botUser);
 


### PR DESCRIPTION
Reverts jenkins-infra/ircbot#81

This isn't the correct fix for the issue. The issue occurs when the users being added as maintainers are not part of the org already. If they are part of the org, they can be passed to the maintainers parameter when building the team, but if they are not part of the org, they need to be added to the team after it is created.