### PR TITLE
Fix response to Hello to show actual username, not the .toString()

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/fallback/FallbackMessage.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/fallback/FallbackMessage.java
@@ -29,7 +29,7 @@ public class FallbackMessage {
         }
 
         if (StringUtils.startsWithIgnoreCase(payload, "hello")) {
-            return "Hello " + sender + "!";
+            return "Hello, " + sender.getNick() + "!";
         }
 
         return new WeightedRandomAnswer()


### PR DESCRIPTION
Currently, it shows all sorts of internal information about the user, this responds with just the nick.