### PR TITLE
Fixes for new hosting checking

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/HostingChecker.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/HostingChecker.java
@@ -118,7 +118,7 @@ public class HostingChecker {
     private void appendIssues(StringBuilder msg, HashSet<VerificationMessage> issues, int level) {
         for(VerificationMessage issue : issues.stream().sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
             if(level == 1) {
-                msg.append(String.format("%s {{color:%s}}%s: %s{{color}}%n", StringUtils.repeat("*", level), issue.getSeverity().getColor(), issue.getSeverity().getMessage(), issue.getMessage()));
+                msg.append(String.format("%s {color:%s}%s: %s{color}%n", StringUtils.repeat("*", level), issue.getSeverity().getColor(), issue.getSeverity().getMessage(), issue.getMessage()));
             } else {
                 msg.append(String.format("%s %s%n", StringUtils.repeat("*", level), issue.getMessage()));
             }

--- a/src/main/java/org/jenkinsci/backend/ircbot/hosting/VerificationMessage.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/hosting/VerificationMessage.java
@@ -69,6 +69,7 @@ public class VerificationMessage implements Comparable<VerificationMessage> {
         private int level;
 
         Severity(int level, String message, String color) {
+            this.level = level;
             this.message = message;
             this.color = color;
         }
@@ -95,6 +96,9 @@ public class VerificationMessage implements Comparable<VerificationMessage> {
     }
 
     public HashSet<VerificationMessage> getSubItems() {
+        if(subItems == null) {
+            subItems = new HashSet<VerificationMessage>();   
+        }
         return subItems;
     }
 


### PR DESCRIPTION
This fixes a couple of small issues with the hosting code

1. The color formatting for issues list had leftover from .NET which requires {{ to escape {
2. The level member was never set in the Severity enum
3. The subItems could be uninitialized when the getter was called.