### PR TITLE
Wrap getUser with try/catch to catch invalid users

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/hosting/GithubVerifier.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/hosting/GithubVerifier.java
@@ -32,8 +32,12 @@ public class GithubVerifier implements Verifier {
                     continue;
                 }
 
-                GHUser ghUser = github.getUser(user.trim());
-                if (ghUser == null || !ghUser.getType().equalsIgnoreCase("user")) {
+                try {
+                    GHUser ghUser = github.getUser(user.trim());
+                    if (ghUser == null || !ghUser.getType().equalsIgnoreCase("user")) {
+                        invalidUsers.add(user.trim());
+                    }
+                } catch(IOException e) {
                     invalidUsers.add(user.trim());
                 }
             }


### PR DESCRIPTION
Currently an exception occurs and exits out of the GitHubVerifier instead of catching the invalid user.