### PR TITLE
Use issue tracker choice field from Jira

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -178,15 +178,15 @@ public class IrcListener extends ListenerAdapter {
     private void handleDirectCommand(Channel channel, User sender, String payload) {
         Matcher m;
 
-        m = Pattern.compile("(?:create|make|add) (\\S+)(?: repository)? (?:on|in) github(?: for (\\S+))?",CASE_INSENSITIVE).matcher(payload);
+        m = Pattern.compile("(?:create|make|add) (\\S+)(?: repository)? (?:on|in) github(?: for (\\S+))?(?: with (jira|github issues))?",CASE_INSENSITIVE).matcher(payload);
         if (m.matches()) {
-            createGitHubRepository(channel, sender, m.group(1), m.group(2), false);
+            createGitHubRepository(channel, sender, m.group(1), m.group(2), m.group(3).toLowerCase().contains("github"));
             return;
         }
 
-        m = Pattern.compile("fork (?:https://github\\.com/)?(\\S+)/(\\S+)(?: on github)?(?: as (\\S+))?",CASE_INSENSITIVE).matcher(payload);
+        m = Pattern.compile("fork (?:https://github\\.com/)?(\\S+)/(\\S+)(?: on github)?(?: as (\\S+))?(?: with (jira|github issues))?",CASE_INSENSITIVE).matcher(payload);
         if (m.matches()) {
-            forkGitHub(channel, sender, m.group(1),m.group(2),m.group(3), emptyList(), false);
+            forkGitHub(channel, sender, m.group(1),m.group(2),m.group(3), emptyList(), m.group(4).toLowerCase().contains("github"));
             return;
         }
 

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -180,13 +180,13 @@ public class IrcListener extends ListenerAdapter {
 
         m = Pattern.compile("(?:create|make|add) (\\S+)(?: repository)? (?:on|in) github(?: for (\\S+))?",CASE_INSENSITIVE).matcher(payload);
         if (m.matches()) {
-            createGitHubRepository(channel, sender, m.group(1), m.group(2));
+            createGitHubRepository(channel, sender, m.group(1), m.group(2), false);
             return;
         }
 
         m = Pattern.compile("fork (?:https://github\\.com/)?(\\S+)/(\\S+)(?: on github)?(?: as (\\S+))?",CASE_INSENSITIVE).matcher(payload);
         if (m.matches()) {
-            forkGitHub(channel, sender, m.group(1),m.group(2),m.group(3), emptyList());
+            forkGitHub(channel, sender, m.group(1),m.group(2),m.group(3), emptyList(), false);
             return;
         }
 

--- a/src/main/java/org/jenkinsci/backend/ircbot/JiraHelper.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/JiraHelper.java
@@ -39,6 +39,9 @@ import java.util.concurrent.TimeoutException;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 import org.jenkinsci.backend.ircbot.util.ConnectionInfo;
 
 /**
@@ -51,6 +54,7 @@ public class JiraHelper {
     public static final String FORK_TO_JIRA_FIELD = "customfield_10321";
     public static final String FORK_FROM_JIRA_FIELD = "customfield_10320";
     public static final String USER_LIST_JIRA_FIELD = "customfield_10323";
+    public static final String ISSUE_TRACKER_JIRA_FIELD = "customfield_11320";
     public static final String DONE_JIRA_RESOLUTION_NAME = "Done";
     
     /**
@@ -150,7 +154,21 @@ public class JiraHelper {
             if (thisFieldId.equalsIgnoreCase(fieldId)) {
                 Object _value = val.getValue();
                 if (_value != null) {
-                    res = _value.toString();
+                    if(_value instanceof  String) {
+                        res = (String) _value;
+                        break;
+                    } else if (_value instanceof JSONObject) {
+                        JSONObject _jsonValue = (JSONObject)_value;
+                        if(_jsonValue.has("value")) {
+                            try {
+                                res = _jsonValue.getString("value");
+                                break;
+                            } catch(JSONException e) {
+                                // we should log this?
+                                res = defaultValue;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -69,7 +69,7 @@ public class IrcListenerTest extends TestCase {
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
 
-        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
+        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 
     public void testForkOriginSameNameAsExisting() throws Exception {
@@ -132,7 +132,7 @@ public class IrcListenerTest extends TestCase {
         ImmutableSortedSet.Builder<UserLevel> builder = ImmutableSortedSet.naturalOrder();
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
-        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
+        assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 
     public void testForkOriginSameNameAsRenamed() throws Exception {
@@ -202,6 +202,6 @@ public class IrcListenerTest extends TestCase {
         ImmutableSortedSet.Builder<UserLevel> builder = ImmutableSortedSet.naturalOrder();
         builder.add(UserLevel.VOICE);
         when(sender.getUserLevels(chan)).thenReturn(builder.build());
-        assertTrue(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList()));
+        assertTrue(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 }


### PR DESCRIPTION
This pulls in the issue tracker choice field and only creates a component in Jira if the person selected Jira as the issue tracker of choice. If they select Github Issues, then GH Issues are not disabled on the repo.