### PR TITLE
feat: add `archive repo` command

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -1053,7 +1053,6 @@ public class IrcListener extends ListenerAdapter {
                 insufficientPermissionError(channel, false);
                 return;
             }
-            out.message("Archiving " + repo + " and prefixing its description with " + description);
 
             GitHub github = GitHub.connect();
             GHOrganization o = github.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION);
@@ -1071,6 +1070,7 @@ public class IrcListener extends ListenerAdapter {
 
             if (description != "") {
                 orig.setDescription(description);
+                out.message("Description of the repository " + repo + " changed to: " + description);
             }
             orig.archive()
             out.message("The repository has been archived: https://github.com/" + IrcBotConfig.GITHUB_ORGANIZATION + "/" + repo);

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -199,7 +199,7 @@ public class IrcListener extends ListenerAdapter {
             return;
         }
 
-        m = Pattern.compile("archive (?:github )repo (\\S+) and prefix repo description with (\\S+)",CASE_INSENSITIVE).matcher(payload);
+        m = Pattern.compile("archive (?:github )repo (\\S+) (\\S+)",CASE_INSENSITIVE).matcher(payload);
         if (m.matches()) {
             archiveGitHubRepo(channel, sender, m.group(1), m.group(2));
             return;

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcListener.java
@@ -1041,19 +1041,19 @@ public class IrcListener extends ListenerAdapter {
     }
 
     /**
-     * Archive a repository and add a prefix to its description (ex: archive explanation)
+     * Archive a repository and optionally replace its description (with archive explanation for example)
      *
-     * @param descriptionPrefix
-     *      Prefix added to the repository description (ex: archive explanation)
+     * @param description
+     *      Repository description (ex: archive explanation)
      */
-    private void archiveGitHubRepo(Channel channel, User sender, String repo, String descriptionPrefix) {
+    private void archiveGitHubRepo(Channel channel, User sender, String repo, String description) {
         OutputChannel out = channel.send();
         try {
             if (!isSenderAuthorized(channel, sender, false)) {
                 insufficientPermissionError(channel, false);
                 return;
             }
-            out.message("Archiving " + repo + " and prefixing its description with " + descriptionPrefix);
+            out.message("Archiving " + repo + " and prefixing its description with " + description);
 
             GitHub github = GitHub.connect();
             GHOrganization o = github.getOrganization(IrcBotConfig.GITHUB_ORGANIZATION);
@@ -1069,8 +1069,8 @@ public class IrcListener extends ListenerAdapter {
                 return;
             }
 
-            if (descriptionPrefix != "") {
-                orig.setDescription(descriptionPrefix + orig.getDescription());
+            if (description != "") {
+                orig.setDescription(description);
             }
             orig.archive()
             out.message("The repository has been archived: https://github.com/" + IrcBotConfig.GITHUB_ORGANIZATION + "/" + repo);


### PR DESCRIPTION
This new command allows archiving a repository, and optionally replace its description.

Additional PR to update [the IRC Bot page on jenkins.io](https://www.jenkins.io/projects/infrastructure/ircbot/):
https://github.com/jenkins-infra/jenkins.io/pull/5487

Fix https://github.com/jenkins-infra/ircbot/issues/107