### PR TITLE
Use temurin 8 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:8-alpine
+# TODO: Bump to JDK11 and generate a JRE with jlink - https://hub.docker.com/_/eclipse-temurin#CreatingaJREusingjlink
+FROM eclipse-temurin:8-jre-alpine
 
 RUN apk update && apk add --no-cache unzip
 RUN adduser -D -h /home/ircbot -u 1013 ircbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre-alpine
+FROM eclipse-temurin:8-alpine
 
 RUN apk update && apk add --no-cache unzip
 RUN adduser -D -h /home/ircbot -u 1013 ircbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM java:8-jre-alpine
 
 RUN apk update && apk add --no-cache unzip
 RUN adduser -D -h /home/ircbot -u 1013 ircbot


### PR DESCRIPTION
I can't locate the current image on the docker hub, the change proposed uses temurin builds.

> [2022-10-12T21:42:21.576Z] manifest for java:openjdk-8-jre-alpine not found: manifest unknown: manifest unknown
