### PR TITLE
chore(Jenkinsfile) update pipeline to use latest practices of jenkins-infra

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,54 +1,39 @@
-#!groovy
+#!/usr/bin/env groovy
 
-def imageName = 'jenkinsciinfra/ircbot'
+pipeline {
+  agent {
+    // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
+    label 'docker || linux-amd64-docker'
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+    timestamps()
+  }
 
-/* Only keep the 5 most recent builds. */
-properties([
-  [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '5']],
-  pipelineTriggers([[$class:"SCMTrigger", scmpoll_spec:"H/10 * * * *"]]),
-])
+  stages {
+    stage('Build') {
+      environment {
+        JAVA_HOME = '/opt/jdk-8/'
+        BUILD_NUMBER = env.GIT_COMMIT.take(6)
+      }
+      steps {
+        sh 'make bot'
+      }
 
-node('docker') {
-    def imageTag
-    stage('Checkout') {
-        deleteDir()
-        checkout scm
-        /* Using this hack right now to grab the appropriate abbreviated SHA1 of
-        * our current build's commit. We must do this because right now I cannot
-        * refer to `env.GIT_COMMIT` in Pipeline scripts
-        */
-        sh 'mvn clean package'
-        sh 'git rev-parse HEAD > GIT_COMMIT'
-        shortCommit = readFile('GIT_COMMIT').take(6)
-        imageTag = "${env.BUILD_ID}-build${shortCommit}"
-    }
-
-    stage('Build ircbot') {
-        withEnv([
-            "BUILD_NUMBER=${env.BUILD_NUMBER}:${shortCommit}",
-            "JAVA_HOME=${tool 'jdk8'}",
-            "PATH+MVN=${tool 'mvn'}/bin",
-        ]) {
-            timestamps {
-                sh 'make bot'
-            }
+      post {
+        always {
+          junit '**/target/surefire-reports/**/*.xml'
         }
-    }
-
-    stage('Archive Test Results') {
-        junit '**/target/surefire-reports/**/*.xml'
-    }
-
-    def whale
-    stage('Build container') {
-        whale = docker.build("${imageName}:${imageTag}", '--no-cache --rm .')
-    }
-
-    if (infra.isTrusted()) {
-        stage('Publish container') {
-            infra.withDockerCredentials {
-                timestamps { whale.push() }
-            }
+        success {
+            stash name: 'binary', includes: 'target/ircbot-2.0-SNAPSHOT-bin.zip'
         }
+      }
     }
+
+    stage('Docker image') {
+      steps {
+        buildDockerAndPublishImage('ircbot', [unstash: 'binary'])
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR updates the pipeline to follow latest Jenkins Infra practises:

- Model is https://github.com/jenkins-infra/plugin-health-scoring/blob/main/Jenkinsfile
- Docker image lint, build, (test) and deployment managed by the central shared library 
- Allow building on both ci.jenkins.io (for contributors) and infra.ci.jenkins.io (for secure deployment)
- Avoid running the maven command twice: the `make bot` command already runs one


Please note that I might be missing 1 or 2 steps: let's check carefully the build results for ci.jenkins.io.

Do not worry for infra.ci.jenkins.io: the job need to be added first (and I'll update pipeline at this time when required)