### PR TITLE
chore(Dockerfile) fix hadolint issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
 # TODO: Bump to JDK11 and generate a JRE with jlink - https://hub.docker.com/_/eclipse-temurin#CreatingaJREusingjlink
 FROM eclipse-temurin:8-jre-alpine
 
-RUN apk update && apk add --no-cache unzip
 RUN adduser -D -h /home/ircbot -u 1013 ircbot
-COPY target/ircbot-2.0-SNAPSHOT-bin.zip /usr/local/bin/ircbot.zip
-RUN cd /usr/local/bin; unzip ircbot.zip
+
+ARG APP_NAME=ircbot-2.0-SNAPSHOT
+COPY "target/${APP_NAME}-bin.zip" /usr/local/bin/ircbot.zip
+
+## Always use the latest "unzip" package version.
+## TODO: change assembly from zip to a jar file to get rid of the "unzip" step here (no need for ZIP)
+# hadolint ignore=DL3018
+RUN apk add --no-cache unzip \
+  && unzip /usr/local/bin/ircbot.zip -d /usr/local/bin \
+  && rm -f ircbot.zip
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
-RUN chmod +x /tini
+ADD "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static" /tini
+RUN chmod a+x /tini
 
 EXPOSE 8080
 USER ircbot
 
+# Persist the variable in the image as an env. variable
+ENV APP_NAME="${APP_NAME}"
 ENTRYPOINT [\
   "/tini", "--",\
   "/bin/sh","-c",\
-  "java -Dircbot.name=jenkins-admin -jar /usr/local/bin/ircbot-2.0-SNAPSHOT.jar"]
+  "java -Dircbot.name=jenkins-admin -jar /usr/local/bin/${APP_NAME}.jar"]


### PR DESCRIPTION
This PR ensures that there are no more hadolint issues by cleaning up the Dockefile.

The previous PR #122 did not show the hadolint errors in the checks because it was using the Jenkinsfile prior of #121 .

Added a note about the maven result: the `Dockerfile can even be simplified if Maven is set up to produce a `jar` (instead of a `zip`).