### PR TITLE
fix: NSFE at WHITESPACE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,10 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -96,18 +100,12 @@
     <dependency>
       <groupId>com.github.pircbotx</groupId>
       <artifactId>pircbotx</artifactId>
-      <version>2.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>master-v2.3-gb1b48bf-9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Removing the guava exclusion appears to fix the NSFE, which tries to access the WHITESPACE field.