### PR TITLE
chore: Test cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,33 +132,15 @@
       <type>jar</type>
     </dependency>
     <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <version>1.1.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
+      <version>4.8.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfoTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfoTest.java
@@ -36,7 +36,7 @@ public class IrcBotBuildInfoTest {
     public void testVersionInfoReal() throws IOException {
         InputStream istream = IrcBotBuildInfo.class.getResourceAsStream("/versionInfo.properties");
         assumingThat(istream != null, () -> {
-            System.out.println("This test is expected to work in https://ci.jenkins-ci.org/job/infra_ircbot/ job only");
+            System.out.println("This test is expected to work in https://ci.jenkins.io/job/Infra/job/ircbot/ job only");
             IrcBotBuildInfo info = IrcBotBuildInfo.readResourceFile("/versionInfo.properties");
             System.out.println(info);
         });

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfoTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfoTest.java
@@ -2,11 +2,10 @@ package org.jenkinsci.backend.ircbot;
 
 import java.io.IOException;
 import java.io.InputStream;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 
@@ -16,6 +15,7 @@ import org.jvnet.hudson.test.Issue;
  */
 public class IrcBotBuildInfoTest {
 
+    @Test
     @Issue("INFRA-135")
     public void testVersionInfoStub() throws IOException {
         IrcBotBuildInfo info = IrcBotBuildInfo.readResourceFile("/versionInfo_test.properties");
@@ -24,7 +24,6 @@ public class IrcBotBuildInfoTest {
         assertEquals("c", info.getBuildID());
         assertEquals("d", info.getBuildURL());
         assertEquals("e", info.getGitCommit());
-        System.out.println(info);
     }
 
     /**
@@ -36,8 +35,10 @@ public class IrcBotBuildInfoTest {
     @Issue("INFRA-135")
     public void testVersionInfoReal() throws IOException {
         InputStream istream = IrcBotBuildInfo.class.getResourceAsStream("/versionInfo.properties");
-        assumeThat("This test is expected to work in https://ci.jenkins-ci.org/job/infra_ircbot/ job only", istream, not(nullValue()));
-        IrcBotBuildInfo info = IrcBotBuildInfo.readResourceFile("/versionInfo.properties");
-        System.out.println(info);
+        assumingThat(istream != null, () -> {
+            System.out.println("This test is expected to work in https://ci.jenkins-ci.org/job/infra_ircbot/ job only");
+            IrcBotBuildInfo info = IrcBotBuildInfo.readResourceFile("/versionInfo.properties");
+            System.out.println(info);
+        });
     }
 }

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotConfigTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotConfigTest.java
@@ -1,19 +1,20 @@
 package org.jenkinsci.backend.ircbot;
 
 import java.util.Map;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link IrcBotConfig}.
  * @author Oleg Nenashev <o.v.nenashev@gmail.com>
  */
-public class IrcBotConfigTest  extends TestCase {
-    
+public class IrcBotConfigTest  {
+    @Test    
     public void testGetConfig() {
         System.out.println("name = " + IrcBotConfig.NAME);
         System.out.println("default JIRA project = " + IrcBotConfig.JIRA_DEFAULT_PROJECT);        
     }
     
+    @Test
     public void testGetIRCHookConfig() {
         Map<String,String> ircHookConfig = IrcBotConfig.getIRCHookConfig();
         
@@ -21,5 +22,4 @@ public class IrcBotConfigTest  extends TestCase {
             System.out.println(e.getKey() + " = " + e.getValue());
         }
     }
-    
 }

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcBotConfigTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcBotConfigTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
  * @author Oleg Nenashev <o.v.nenashev@gmail.com>
  */
 public class IrcBotConfigTest  {
-    @Test    
+    @Test
     public void testGetConfig() {
         System.out.println("name = " + IrcBotConfig.NAME);
         System.out.println("default JIRA project = " + IrcBotConfig.JIRA_DEFAULT_PROJECT);        

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.backend.ircbot;
 
 import com.google.common.collect.ImmutableSortedSet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.kohsuke.github.*;
 import org.mockito.Mockito;
 import org.mockito.MockedStatic;
@@ -25,6 +26,11 @@ import static org.mockito.Mockito.when;
  */
 public class IrcListenerTest {
     static MockedStatic<GitHub> utilities = Mockito.mockStatic(GitHub.class);
+
+    @AfterAll
+    public static void afterClass() throws Exception {
+        utilities.closeOnDemand();
+    }
 
     @Test
     public void testForkGithubExistingRepo() throws Exception {

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.backend.ircbot;
 
 import com.google.common.collect.ImmutableSortedSet;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.github.*;
 import org.mockito.Mockito;

--- a/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/IrcListenerTest.java
@@ -1,23 +1,22 @@
 package org.jenkinsci.backend.ircbot;
 
 import com.google.common.collect.ImmutableSortedSet;
-import junit.framework.TestCase;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.github.*;
 import org.mockito.Mockito;
+import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.pircbotx.Channel;
 import org.pircbotx.User;
 import org.pircbotx.UserLevel;
 import org.pircbotx.output.OutputChannel;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static java.util.Collections.emptyList;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,10 +24,10 @@ import static org.mockito.Mockito.when;
 /**
  * Created by slide on 11/14/2016.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(GitHub.class)
-@PowerMockIgnore("javax.net.ssl.*")
-public class IrcListenerTest extends TestCase {
+public class IrcListenerTest {
+    static MockedStatic<GitHub> utilities = Mockito.mockStatic(GitHub.class);
+
+    @Test
     public void testForkGithubExistingRepo() throws Exception {
         final String repoName = "jenkins";
         final String channel = "#dummy";
@@ -36,10 +35,8 @@ public class IrcListenerTest extends TestCase {
         final String owner = "bar";
         final String from = "foobar";
 
-        PowerMockito.mockStatic(GitHub.class);
-
         GitHub gh = mock(GitHub.class);
-        when(GitHub.connect()).thenReturn(gh);
+        utilities.when(GitHub::connect).thenReturn(gh);
 
         GHRepository repo = mock(GHRepository.class);
 
@@ -67,6 +64,7 @@ public class IrcListenerTest extends TestCase {
         assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 
+    @Test
     public void testForkOriginSameNameAsExisting() throws Exception {
         final String repoName = "some-new-name";
         final String channel = "#dummy";
@@ -74,10 +72,8 @@ public class IrcListenerTest extends TestCase {
         final String owner = "bar";
         final String from = "jenkins";
 
-        PowerMockito.mockStatic(GitHub.class);
-
         GitHub gh = mock(GitHub.class);
-        when(GitHub.connect()).thenReturn(gh);
+        utilities.when(GitHub::connect).thenReturn(gh);
 
         GHRepository originRepo = mock(GHRepository.class);
         final GHRepository newRepo = mock(GHRepository.class);
@@ -130,6 +126,7 @@ public class IrcListenerTest extends TestCase {
         assertFalse(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 
+    @Test
     public void testForkOriginSameNameAsRenamed() throws Exception {
         final String repoName = "some-new-name";
         final String channel = "#dummy";
@@ -137,10 +134,8 @@ public class IrcListenerTest extends TestCase {
         final String owner = "bar";
         final String from = "jenkins";
 
-        PowerMockito.mockStatic(GitHub.class);
-
         GitHub gh = mock(GitHub.class);
-        when(GitHub.connect()).thenReturn(gh);
+        utilities.when(GitHub::connect).thenReturn(gh);
 
         GHRepository originRepo = mock(GHRepository.class);
         final GHRepository newRepo = mock(GHRepository.class);
@@ -200,6 +195,7 @@ public class IrcListenerTest extends TestCase {
         assertTrue(ircListener.forkGitHub(chan, sender, owner, from, repoName, emptyList(), false));
     }
 
+    @Test
     public void testCreateRepoWithNoIssueTracker() throws Exception {
         // see https://github.com/jenkins-infra/ircbot/issues/101
 
@@ -209,10 +205,8 @@ public class IrcListenerTest extends TestCase {
         final String owner = "bar";
         final String from = "foobar";
 
-        PowerMockito.mockStatic(GitHub.class);
-
         GitHub gh = mock(GitHub.class);
-        when(GitHub.connect()).thenReturn(gh);
+        utilities.when(GitHub::connect).thenReturn(gh);
 
         GHUser awesomeUser = mock(GHUser.class);
         when(gh.getUser("awesome-user")).thenReturn(awesomeUser);

--- a/src/test/java/org/jenkinsci/backend/ircbot/fallback/WeightedRandomAnswerTest.java
+++ b/src/test/java/org/jenkinsci/backend/ircbot/fallback/WeightedRandomAnswerTest.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.backend.ircbot.fallback;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WeightedRandomAnswerTest {
 
@@ -42,8 +42,8 @@ public class WeightedRandomAnswerTest {
                 gotC++;
             }
         }
-        assertTrue("Got A " + gotA + " times", 79_000 < gotA && gotA < 81_000);
-        assertTrue("Got B " + gotB + " times", 14_500 < gotB && gotB < 15_500);
-        assertTrue("Got C " + gotC + " times", 4_500 < gotC && gotC < 5_500);
+        assertTrue(79_000 < gotA && gotA < 81_000, "Got A " + gotA + " times");
+        assertTrue(14_500 < gotB && gotB < 15_500, "Got B " + gotB + " times");
+        assertTrue(4_500 < gotC && gotC < 5_500, "Got C " + gotC + " times");
     }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This removes some dependencies that are no longer needed, e.g., PowerMock and updates all the tests to JUnit5.