### PR TITLE
Extend jenkins-infra release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-  # See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-_extends: jenkinsci/.github
+# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
 # Semantic versioning: https://semver.org/
 version-template: $MAJOR.$MINOR.$PATCH
 tag-template: v$NEXT_MINOR_VERSION


### PR DESCRIPTION
The infra org provides the same template we can rely on.