### PR TITLE
chore: Fix version output

### DIFF
--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfo.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotBuildInfo.java
@@ -52,7 +52,7 @@ import java.util.Properties;
 
     @Override
     public String toString() {
-        return String.format("build%s %s (%s)", buildNumber, gitCommit, buildDate);
+        return String.format("build-%s %s (%s)", buildNumber, gitCommit, buildDate);
     }
     
     private static String readProperty(Properties propFile, String key) throws IOException {


### PR DESCRIPTION
Adds dash between word `build` and the actual build number. 