### PR TITLE
Connect to hosting channel only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         BUILD_NUMBER = env.GIT_COMMIT.take(6)
       }
       steps {
-        sh 'make bot'
+        sh 'make clean bot'
       }
 
       post {

--- a/src/main/java/org/jenkinsci/backend/ircbot/IrcBotConfig.java
+++ b/src/main/java/org/jenkinsci/backend/ircbot/IrcBotConfig.java
@@ -28,8 +28,8 @@ public class IrcBotConfig {
     private static final String DEFAULT_IRCBOT_NAME = ("ircbot-"+System.getProperty("user.name"));
     static String NAME = System.getProperty(varPrefix+"name", DEFAULT_IRCBOT_NAME);
     static String SERVER = System.getProperty(varPrefix+"server", "irc.libera.chat");
-    static final Set<String> DEFAULT_CHANNELS = new HashSet<String>(Arrays.asList("#jenkins", "#jenkins-infra", "#jenkins-release", "#jenkins-hosting"));
-    static final String CHANNELS_LIST = System.getProperty(varPrefix+"channels", "#jenkins,#jenkins-infra,#jenkins-release,#jenkins-hosting");
+    static final Set<String> DEFAULT_CHANNELS = new HashSet<String>(Arrays.asList("#jenkins-hosting"));
+    static final String CHANNELS_LIST = System.getProperty(varPrefix+"channels", "#jenkins-hosting");
 
     // Testing
     /**


### PR DESCRIPTION
With the desync of chat rooms from IRC to matrix and the people affected by it using Matrix only, I'd propose to make the bot leave all channels but the hosting one, it actually serves in.